### PR TITLE
Changed; "background" explanation's grammar

### DIFF
--- a/docs/07-BDD.md
+++ b/docs/07-BDD.md
@@ -400,7 +400,7 @@ Let's improve our BDD suite by using the advanced features of Gherkin language.
 
 ### Background
 
-If a group of scenarios have the same initial steps, let's that for dashboard we need always need to be logged in as administrator. We can use *Background* section to do the required preparations and not to repeat same steps across scenarios.
+If a group of scenarios have the same initial steps we can define a *Background* section to be used prior to those steps being run. This allows us to avoid repeating our steps across multiple scenarios. Let's say that for the dashboard feature we always need to be logged in as administrator.
 
 {% highlight gherkin %}
 


### PR DESCRIPTION
Changed the "background" explanations sentence structure to be clearer to understand, and corrected several grammar mistakes in the process.